### PR TITLE
Fix newsletter modal `user_type` missing on repeat submissions and update success message

### DIFF
--- a/components/NewsletterModal.tsx
+++ b/components/NewsletterModal.tsx
@@ -35,13 +35,14 @@ export default function Newsletter(data: ISubscribeDialog) {
     agree: false,
     location: "",
   });
-
+  
+  // Initialize form data with user type
   useEffect(() => {
   if (open) {
     setFormData((f) => ({
       ...f,
       location: f.location,
-      user_type, // always refresh from props
+      user_type, 
     }));
   }
 }, [open, user_type]);

--- a/components/NewsletterModal.tsx
+++ b/components/NewsletterModal.tsx
@@ -24,7 +24,7 @@ interface ISubscribeError {
 interface ISubscribeDialog {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  user_type: "listener" | "preacher" ;
+  user_type: "listener" | "preacher";
 }
 export default function Newsletter(data: ISubscribeDialog) {
   const { open, onOpenChange, user_type } = data;
@@ -35,6 +35,16 @@ export default function Newsletter(data: ISubscribeDialog) {
     agree: false,
     location: "",
   });
+
+  useEffect(() => {
+  if (open) {
+    setFormData((f) => ({
+      ...f,
+      location: f.location,
+      user_type, // always refresh from props
+    }));
+  }
+}, [open, user_type]);
 
   const [errors, setErrors] = useState<ISubscribeError>({});
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -151,8 +161,8 @@ export default function Newsletter(data: ISubscribeDialog) {
         throw new Error(data.error || "Something went wrong");
       }
 
-      toast.success("You're on the list!", {
-        description: "We'll let you know when the app is ready.",
+      toast.success("Invite Sent!", {
+        description: "Check your email to join us.",
       });
 
       // Optionally close modal
@@ -180,136 +190,144 @@ export default function Newsletter(data: ISubscribeDialog) {
 
   return (
     <>
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="container mx-auto sm:px-8 py-10 bg-white dark:bg-neutral-900 dark:text-white sm:max-w-[500px] items-start justify-start border border-neutral-900">
-        <div className="mb-2 flex flex-col gap-2">
-
-          <div className="mb-2 flex items-center justify-center">
-            <Image
-              src="/images/mail-icon.png"
-              alt="logo"
-              width={100}
-              height={100}
-            />
-          </div>
-
-          <DialogHeader className="items-start justify-start">
-            <DialogTitle className="text-5xl text-start dark:text-white">
-              Stay rooted in God’s word. Get early access!
-            </DialogTitle>
-
-            <DialogDescription className="text-start text-lg pt-4 dark:text-neutral-400">
-              Troott is the new mobile space for life-giving sermons
-              and spiritual nourishment, anytime, anywhere.
-              Signup below to get your invite:
-            </DialogDescription>
-          </DialogHeader>
-        </div>
-
-        <form className="space-y-5">
-          <div className="flex flex-col gap-2 mt-1 ">
-            <div className="relative">
-              <User className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground/80  dark:text-neutral-400" />
-              <Input
-                id="firstName"
-                type="text"
-                placeholder="first name"
-                value={formData.firstName}
-                onChange={handleInputChange("firstName")}
-                onBlur={handleBlur("firstName")}
-                className={cx(
-                  "pl-10 h-12 border text-muted-foreground text-[16px]", // base thin border
-                  "focus:border-teal-400 dark:focus:border-teal-400 focus:outline-none",
-                  "dark:border-neutral-700 dark:text-neutral-300",
-                  errors.firstName && touched.firstName && "border-destructive"
-                )}
-                aria-invalid={!!errors.firstName}
-                aria-describedby={
-                  errors.firstName ? "firstName-error" : undefined
-                }
+      <Dialog open={open} onOpenChange={onOpenChange}>
+        <DialogContent className="container mx-auto sm:px-8 py-10 bg-white dark:bg-neutral-900 dark:text-white sm:max-w-[500px] items-start justify-start border border-neutral-900">
+          <div className="mb-2 flex flex-col gap-2">
+            <div className="mb-2 flex items-center justify-center">
+              <Image
+                src="/images/mail-icon.png"
+                alt="logo"
+                width={100}
+                height={100}
               />
             </div>
 
-            {errors.firstName && touched.firstName && (
-              <p id="firstName-error" className="text-sm text-red-400 mt-1">
-                {errors.firstName}
-              </p>
-            )}
+            <DialogHeader className="items-start justify-start">
+              <DialogTitle className="text-5xl text-start dark:text-white">
+                Stay rooted in God’s word. Get early access!
+              </DialogTitle>
+
+              <DialogDescription className="text-start text-lg pt-4 dark:text-neutral-400">
+                Troott is the new mobile space for life-giving sermons and
+                spiritual nourishment, anytime, anywhere. Signup below to get
+                your invite:
+              </DialogDescription>
+            </DialogHeader>
           </div>
 
-          <div className="flex flex-col gap-2 mt-1 ">
-            <div className="relative">
-              <MailIcon className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground dark:text-neutral-400" />
-              <Input
-                id="email"
-                type="email"
-                placeholder="your email"
-                value={formData.email}
-                onChange={handleInputChange("email")}
-                onBlur={handleBlur("email")}
-                className={cx(
-                  "pl-10 h-12 border text-muted-foreground text-[16px]",
-                  "focus:border-teal-400 dark:focus:border-teal-400 focus:outline-none",
-                  "dark:border-neutral-700 dark:text-neutral-300",
-                  errors.email && touched.email && "border-destructive"
-                )}
-                aria-invalid={!!errors.email}
-                aria-describedby={errors.email ? "email-error" : undefined}
-              />
+          <form className="space-y-5">
+            <div className="flex flex-col gap-2 mt-1 ">
+              <div className="relative">
+                <User className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground/80  dark:text-neutral-400" />
+                <Input
+                  id="firstName"
+                  type="text"
+                  placeholder="first name"
+                  value={formData.firstName}
+                  onChange={handleInputChange("firstName")}
+                  onBlur={handleBlur("firstName")}
+                  className={cx(
+                    "pl-10 h-12 border text-muted-foreground text-[16px]", // base thin border
+                    "focus:border-teal-400 dark:focus:border-teal-400 focus:outline-none",
+                    "dark:border-neutral-700 dark:text-neutral-300",
+                    errors.firstName &&
+                      touched.firstName &&
+                      "border-destructive"
+                  )}
+                  aria-invalid={!!errors.firstName}
+                  aria-describedby={
+                    errors.firstName ? "firstName-error" : undefined
+                  }
+                />
+              </div>
+
+              {errors.firstName && touched.firstName && (
+                <p id="firstName-error" className="text-sm text-red-400 mt-1">
+                  {errors.firstName}
+                </p>
+              )}
             </div>
 
-            {errors.email && touched.email && (
-              <p id="email-error" className="text-sm text-red-400 mt-1">
-                {errors.email}
-              </p>
-            )}
-          </div>
+            <div className="flex flex-col gap-2 mt-1 ">
+              <div className="relative">
+                <MailIcon className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground dark:text-neutral-400" />
+                <Input
+                  id="email"
+                  type="email"
+                  placeholder="your email"
+                  value={formData.email}
+                  onChange={handleInputChange("email")}
+                  onBlur={handleBlur("email")}
+                  className={cx(
+                    "pl-10 h-12 border text-muted-foreground text-[16px]",
+                    "focus:border-teal-400 dark:focus:border-teal-400 focus:outline-none",
+                    "dark:border-neutral-700 dark:text-neutral-300",
+                    errors.email && touched.email && "border-destructive"
+                  )}
+                  aria-invalid={!!errors.email}
+                  aria-describedby={errors.email ? "email-error" : undefined}
+                />
+              </div>
 
-          {/* Privacy Checkbox */}
-          <div className="flex items-start gap-2 text-neutral-400">
-            <Checkbox
-              id="privacy"
-              checked={formData.agree}
-              onCheckedChange={handleCheckboxChange}
+              {errors.email && touched.email && (
+                <p id="email-error" className="text-sm text-red-400 mt-1">
+                  {errors.email}
+                </p>
+              )}
+            </div>
+
+            {/* Privacy Checkbox */}
+            <div className="flex items-start gap-2 text-neutral-400">
+              <Checkbox
+                id="privacy"
+                checked={formData.agree}
+                onCheckedChange={handleCheckboxChange}
+              />
+              <Label
+                htmlFor="privacy"
+                className="text-sm dark:text-neutral-400"
+              >
+                By subscribing you agree to our{" "}
+                <a href="#" className="  text-neutral-300/80">
+                  Privacy Policy
+                </a>
+                .
+              </Label>
+            </div>
+
+            <input type="hidden" value={formData.location} name="location" />
+            <input
+              type="hidden"
+              name="user_type"
+              value={data.user_type || ""}
             />
-            <Label htmlFor="privacy" className="text-sm dark:text-neutral-400">
-              By subscribing you agree to our{" "}
-              <a href="#" className="  text-neutral-300/80">
-                Privacy Policy
-              </a>
-              .
-            </Label>
-          </div>
 
-          <input type="hidden" value={formData.location} name="location" />
-          <input type="hidden" name="user_type" value={data.user_type || ""} />
-
-          <Button
-            type="button"
-            disabled={
-              !formData.firstName ||
-              !formData.email ||
-              !formData.agree ||
-              isSubmitting
-            }
-            onClick={handleSubmit}
-            className={cx(
-              "pl-10 h-12 disabled:opacity-50 disabled:cursor-not-allowed text-lg items-center justify-center",
-              "w-full dark:bg-teal-400 dark:text-neutral-900 dark:hover:bg-teal-300",
-              errors.email &&
-                touched.email &&
-                "border-destructive focus-visible:ring-destructive"
-            )}
-            aria-invalid={errors.email && touched.email ? "true" : "false"}
-            aria-describedby={
-              errors.email && touched.email ? "firstName-error" : undefined
-            }
-          >
-            {isSubmitting ? "Submitting..." : "Sign me up"}
-          </Button>
-        </form>
-      </DialogContent>
-    </Dialog>
+            <Button
+              type="button"
+              disabled={
+                !formData.firstName ||
+                !formData.email ||
+                !formData.agree ||
+                isSubmitting
+              }
+              onClick={handleSubmit}
+              className={cx(
+                "pl-10 h-12 disabled:opacity-50 disabled:cursor-not-allowed text-lg items-center justify-center",
+                "w-full dark:bg-teal-400 dark:text-neutral-900 dark:hover:bg-teal-300",
+                errors.email &&
+                  touched.email &&
+                  "border-destructive focus-visible:ring-destructive"
+              )}
+              aria-invalid={errors.email && touched.email ? "true" : "false"}
+              aria-describedby={
+                errors.email && touched.email ? "firstName-error" : undefined
+              }
+            >
+              {isSubmitting ? "Submitting..." : "Sign me up"}
+            </Button>
+          </form>
+        </DialogContent>
+      </Dialog>
     </>
   );
 }


### PR DESCRIPTION
This PR addresses an issue where the `Newsletter` signup modal failed to include `user_type` when reopened for a second submission. The `user_type` was only set on the initial mount, so subsequent opens using different entry points (e.g., "Listener" vs "Preacher") would send an empty or stale value, resulting in backend validation errors (`field missing`).

The fix ensures `user_type` is refreshed from props each time the modal opens, preserving the value in `formData` without overwriting other fields like `location`.

Additionally, the success toast has been updated to provide a clearer, more action-oriented confirmation message:

```js
toast.success("Invite Sent!", {
  description: "Check your email to join us.",
});
```

**Changes**

* Updated `useEffect` in `Newsletter` to sync `user_type` from props when modal opens.
* Kept existing `formData` fields intact (e.g., location, name, email).
* Updated success toast title and description for better UX clarity.

**Testing**

* Open modal via both “Listener” and “Preacher” buttons, submit valid data, verify backend receives correct `user_type`.
* Reopen modal with a different button, change details, resubmit — backend still receives correct `user_type`.
* Verify success toast displays new message format.